### PR TITLE
Upgrade Log4j

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'application'
 }
 
-version '3.0-SNAPSHOT'
+version '4.0-SNAPSHOT'
 
 repositories {
     mavenCentral()
@@ -14,8 +14,8 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 
     implementation 'org.apache.zookeeper:zookeeper:3.7.0'
-    implementation 'org.apache.logging.log4j:log4j-api:2.14.1'
-    implementation 'org.apache.logging.log4j:log4j-core:2.14.1'
+    implementation 'org.apache.logging.log4j:log4j-api:2.15.0'
+    implementation 'org.apache.logging.log4j:log4j-core:2.15.0'
 
 //    compile group: 'org.apache.zookeeper', name: 'zookeeper', version: '3.6.2'
     implementation group: 'com.beust', name: 'jcommander', version: '1.81'

--- a/integration/test_integration.py
+++ b/integration/test_integration.py
@@ -28,7 +28,7 @@ ZK_HOME_DIR = Path(os.environ.get('ZK_HOME_DIR', '../apache-zookeeper-3.7.0-bin'
 # LIBS_DIR - Optional. The directory in which the jar is located.
 LIBS_DIR = Path(os.environ.get('LIBS_DIR', '../build/libs'))
 
-JAR_NAME = 'zgroups-3.0-SNAPSHOT.jar'
+JAR_NAME = 'zgroups-4.0-SNAPSHOT.jar'
 
 JAR_PATH = str((LIBS_DIR / JAR_NAME).absolute())
 


### PR DESCRIPTION
Log4j has a high-impact vulnerability. Upgrading to `2.15.0` should patch the vuln.
